### PR TITLE
Fix multibyte + simplifications

### DIFF
--- a/crosshairs.kak
+++ b/crosshairs.kak
@@ -16,9 +16,9 @@ define-command -hidden highlight-current-column %{ evaluate-commands -save-regs 
         }
     }
     set-register C %sh{
-        echo $(((kak_cursor_column - kak_main_reg_T) + (kak_main_reg_T * kak_opt_tabstop)))
+        echo $(((kak_cursor_char_column - kak_main_reg_T) + (kak_main_reg_T * kak_opt_tabstop)))
     }
-    add-highlighter window/cursor-column column %reg(C) %opt{highlight_line_face}
+    add-highlighter window/cursor-column column %reg{C} %opt{highlight_line_face}
 }}
 
 define-command -hidden highlight-current-line -docstring "Highlight current line" %{

--- a/crosshairs.kak
+++ b/crosshairs.kak
@@ -20,12 +20,8 @@ define-command -hidden highlight-current-column %{ evaluate-commands -save-regs 
 }}
 
 define-command -hidden highlight-current-line -docstring "Highlight current line" %{
-    try %{ remove-highlighter %opt{line_high_path} }
-
-    declare-option str line_high_path %sh{
-        echo "window/line_${kak_cursor_line}_${kak_opt_highlight_line_face}"
-    }
-    add-highlighter window/ line %val{cursor_line} %opt{highlight_line_face}
+    try %{ remove-highlighter window/cursor-line }
+    add-highlighter window/cursor-line line %val{cursor_line} %opt{highlight_line_face}
 }
 
 hook global NormalKey .+ show-line-col-highlighters
@@ -52,7 +48,7 @@ define-command toggle-crosshairs -docstring "Toggle Crosshairs or line/col highl
         if [ "$kak_opt_crosshair_mode" = true ] ; then
             echo 'set-option global crosshair_mode false'
             echo 'try %(remove-highlighter window/cursor-column)'
-            echo 'try %( remove-highlighter %opt{line_high_path} )'           
+            echo 'try %(remove-highlighter window/cursor-line)'
         else
             echo 'set-option global crosshair_mode true'
             echo 'highlight-current-line; highlight-current-column'
@@ -64,7 +60,7 @@ define-command toggle-current-line-highlight -docstring "Toggle Highlighting for
     eval %sh{
         if [ "$kak_opt_highlight_current_line" = true ] ; then
             echo 'set-option global highlight_current_line false'
-            echo 'try %(remove-highlighter %opt{line_high_path})'                      
+            echo 'try %(remove-highlighter window/cursor-line)'
         else
             echo 'set-option global highlight_current_line true'
             echo 'highlight-current-line'
@@ -81,7 +77,7 @@ define-command toggle-current-column-highlight -docstring "Toggle highlighting f
             echo 'set-option global highlight_current_column true'
             echo 'highlight-current-column'
         fi
-    } 
+    }
 }
 
 

--- a/crosshairs.kak
+++ b/crosshairs.kak
@@ -24,8 +24,7 @@ define-command -hidden highlight-current-line -docstring "Highlight current line
     add-highlighter window/cursor-line line %val{cursor_line} %opt{highlight_line_face}
 }
 
-hook global NormalKey .+ show-line-col-highlighters
-hook global InsertKey .+ show-line-col-highlighters
+hook global RawKey .+ show-line-col-highlighters
 
 define-command -hidden show-line-col-highlighters %{
     eval %sh{

--- a/crosshairs.kak
+++ b/crosshairs.kak
@@ -3,28 +3,28 @@ declare-option bool crosshair_mode true
 declare-option bool highlight_current_line false
 declare-option bool highlight_current_column false
 
+hook global RawKey .+ update-line-col-highlighters
+
 define-command -hidden highlight-current-column %{ evaluate-commands -save-regs 'CT' %{
-  try %(remove-highlighter window/cursor-column)
-  evaluate-commands -draft %{
-    try %{
-      execute-keys '<space><a-h>s\t<ret>'
-      set-register T %sh(count() { echo $#; }; count $kak_selections_desc)
-    } catch %{
-      set-register T 0
+    try %(remove-highlighter window/cursor-column)
+    evaluate-commands -draft %{
+        try %{
+            execute-keys '<space><a-h>s\t<ret>'
+            set-register T %sh(count() { echo $#; }; count $kak_selections_desc)
+        } catch %{
+            set-register T 0
+        }
     }
-  }
-  set-register C %sh{
-    echo $(((kak_cursor_column - kak_main_reg_T) + (kak_main_reg_T * kak_opt_tabstop)))
-  }
-  add-highlighter window/cursor-column column %reg(C) %opt{highlight_line_face}
+    set-register C %sh{
+        echo $(((kak_cursor_column - kak_main_reg_T) + (kak_main_reg_T * kak_opt_tabstop)))
+    }
+    add-highlighter window/cursor-column column %reg(C) %opt{highlight_line_face}
 }}
 
 define-command -hidden highlight-current-line -docstring "Highlight current line" %{
     try %{ remove-highlighter window/cursor-line }
-    add-highlighter window/cursor-line line %val{cursor_line} %opt{highlight_line_face}
+    try %{ add-highlighter window/cursor-line line %val{cursor_line} %opt{highlight_line_face} }
 }
-
-hook global RawKey .+ update-line-col-highlighters
 
 define-command -hidden update-line-col-highlighters %{ evaluate-commands %sh{
     if [ "$kak_opt_crosshair_mode" = "true" ]; then

--- a/crosshairs.kak
+++ b/crosshairs.kak
@@ -24,10 +24,10 @@ define-command -hidden highlight-current-line -docstring "Highlight current line
     add-highlighter window/cursor-line line %val{cursor_line} %opt{highlight_line_face}
 }
 
-hook global RawKey .+ show-line-col-highlighters
+hook global RawKey .+ update-line-col-highlighters
 
-define-command -hidden show-line-col-highlighters %{
-    eval %sh{
+define-command -hidden update-line-col-highlighters %{
+    evaluate-commands %sh{
         if [ "$kak_opt_crosshair_mode" = true ] ; then
           echo "highlight-current-line ; highlight-current-column"
         fi
@@ -43,7 +43,7 @@ define-command -hidden show-line-col-highlighters %{
 }
 
 define-command toggle-crosshairs -docstring "Toggle Crosshairs or line/col highlighting" %{
-    eval %sh{
+    evaluate-commands %sh{
         if [ "$kak_opt_crosshair_mode" = true ] ; then
             echo 'set-option global crosshair_mode false'
             echo 'try %(remove-highlighter window/cursor-column)'
@@ -56,7 +56,7 @@ define-command toggle-crosshairs -docstring "Toggle Crosshairs or line/col highl
 }
 
 define-command toggle-current-line-highlight -docstring "Toggle Highlighting for current line" %{
-    eval %sh{
+    evaluate-commands %sh{
         if [ "$kak_opt_highlight_current_line" = true ] ; then
             echo 'set-option global highlight_current_line false'
             echo 'try %(remove-highlighter window/cursor-line)'
@@ -68,7 +68,7 @@ define-command toggle-current-line-highlight -docstring "Toggle Highlighting for
 }
 
 define-command toggle-current-column-highlight -docstring "Toggle highlighting for current column" %{
-    eval %sh{
+    evaluate-commands %sh{
         if [ "$kak_opt_highlight_current_column" = true ] ; then
             echo 'set-option global highlight_current_column false'
             echo 'try %(remove-highlighter window/cursor-column)'

--- a/crosshairs.kak
+++ b/crosshairs.kak
@@ -26,21 +26,14 @@ define-command -hidden highlight-current-line -docstring "Highlight current line
 
 hook global RawKey .+ update-line-col-highlighters
 
-define-command -hidden update-line-col-highlighters %{
-    evaluate-commands %sh{
-        if [ "$kak_opt_crosshair_mode" = true ] ; then
-          echo "highlight-current-line ; highlight-current-column"
-        fi
-
-        if [ "$kak_opt_highlight_current_line" = true ] ; then
-          echo "highlight-current-line"
-        fi
-
-        if [ "$kak_opt_highlight_current_column" = true ] ; then
-          echo "highlight-current-column"
-        fi
-    }
-}
+define-command -hidden update-line-col-highlighters %{ evaluate-commands %sh{
+    if [ "$kak_opt_crosshair_mode" = "true" ]; then
+        echo "highlight-current-line; highlight-current-column"
+    else
+        [ "$kak_opt_highlight_current_line" = "true" ] && echo "highlight-current-line"
+        [ "$kak_opt_highlight_current_column" = "true" ] && echo "highlight-current-column"
+    fi
+}}
 
 define-command toggle-crosshairs -docstring "Toggle Crosshairs or line/col highlighting" %{
     evaluate-commands %sh{


### PR DESCRIPTION
Hi, I've found some ways to simplify your code, and decided to do it.

I've changed how input is handled, because in your original method cases like gj weren't handled properly.

I've also changed logic of `show-line-col` function, to skip 2nd half if crosshairs enabled, since it is extra work that doesn't really necessary.

I've changed some names and fixed indentation to make code little more consistent.

Also I've simplified `highlight-current-line` function.

This PR also fixes #6 

Before:
![image](https://user-images.githubusercontent.com/19470159/50765550-46d8a980-1287-11e9-97ee-117ea5704e8e.png)

After:
![image](https://user-images.githubusercontent.com/19470159/50765525-34f70680-1287-11e9-8459-387acc373f57.png)

It also fixes #1, I suppose