### PR TITLE
Improve performance by removing shell expansions from hooks

### DIFF
--- a/crosshairs.kak
+++ b/crosshairs.kak
@@ -3,7 +3,9 @@ set-face global crosshairs_column default,rgb:383838+bd
 
 declare-option bool crosshair_mode false
 declare-option bool highlight_current_line false
+declare-option str highlight_current_line_hook_cmd "nop"
 declare-option bool highlight_current_column false
+declare-option str highlight_current_column_hook_cmd "nop"
 
 define-command -hidden crosshairs-highlight-column %{ evaluate-commands -save-regs 'CT' %{
     try %(remove-highlighter window/crosshairs-column)
@@ -26,13 +28,10 @@ define-command -hidden crosshairs-highlight-line -docstring "Highlight current l
     try %{ add-highlighter window/crosshairs-line line %val{cursor_line} crosshairs_line }
 }
 
-define-command -hidden crosshairs-update %{ evaluate-commands %sh{
-    if [ "$kak_opt_crosshair_mode" = "true" ]; then
-        printf "%s\n" "crosshairs-highlight-line; crosshairs-highlight-column"
-    else
-        [ "$kak_opt_highlight_current_line" = "true" ] && printf "%s\n" "crosshairs-highlight-line"
-        [ "$kak_opt_highlight_current_column" = "true" ] && printf "%s\n" "crosshairs-highlight-column"
-    fi
+define-command -hidden crosshairs-update %{
+    evaluate-commands %{
+    %opt(highlight_current_line_hook_cmd)
+    %opt(highlight_current_column_hook_cmd)
 }}
 
 define-command crosshairs -docstring "Toggle Crosshairs or line/col highlighting" %{
@@ -42,10 +41,14 @@ define-command crosshairs -docstring "Toggle Crosshairs or line/col highlighting
             printf "%s\n" "try %(remove-highlighter window/crosshairs-column)"
             printf "%s\n" "try %(remove-highlighter window/crosshairs-line)"
             printf "%s\n" "remove-hooks global crosshairs"
+            printf "%s\n" "set-option global highlight_current_line_hook_cmd nop"
+            printf "%s\n" "set-option global highlight_current_column_hook_cmd nop"
         else
             printf "%s\n" "set-option global crosshair_mode true"
             printf "%s\n" "crosshairs-highlight-line; crosshairs-highlight-column"
             printf "%s\n" "hook global -group crosshairs RawKey .+ crosshairs-update"
+            printf "%s\n" "set-option global highlight_current_line_hook_cmd crosshairs-highlight-line"
+            printf "%s\n" "set-option global highlight_current_column_hook_cmd crosshairs-highlight-column"
         fi
     }
 }
@@ -56,10 +59,12 @@ define-command cursorline -docstring "Toggle Highlighting for current line" %{
             printf "%s\n" "set-option global highlight_current_line false"
             printf "%s\n" "try %(remove-highlighter window/crosshairs-line)"
             printf "%s\n" "remove-hooks global crosshairs"
+            printf "%s\n" "set-option global highlight_current_line_hook_cmd nop"
         else
             printf "%s\n" "set-option global highlight_current_line true"
             printf "%s\n" "crosshairs-highlight-line"
             printf "%s\n" "hook global -group crosshairs RawKey .+ crosshairs-update"
+            printf "%s\n" "set-option global highlight_current_line_hook_cmd crosshairs-highlight-line"
         fi
     }
 }
@@ -70,10 +75,12 @@ define-command cursorcolumn -docstring "Toggle highlighting for current column" 
             printf "%s\n" "set-option global highlight_current_column false"
             printf "%s\n" "try %(remove-highlighter window/crosshairs-column)"
             printf "%s\n" "remove-hooks global crosshairs"
+            printf "%s\n" "set-option global highlight_current_column_hook_cmd nop"
         else
             printf "%s\n" "set-option global highlight_current_column true"
             printf "%s\n" "crosshairs-highlight-column"
             printf "%s\n" "hook global -group crosshairs RawKey .+ crosshairs-update"
+            printf "%s\n" "set-option global highlight_current_column_hook_cmd crosshairs-highlight-column"
         fi
     }
 }


### PR DESCRIPTION
I noticed there was a bit of visual lag when crosshairs was activated, so here is my attempt to optimize it a little bit. This lag can be most easily noticed when using the mouse to select text.  

The idea is to remove shell expansions from the RawKey hooks. Calling the shell is expensive, and the shell itself is slow. So, if possible, it shouldn't be used in performance sensitive hooks like RawKey.  
Ideally, I think the crosshairs feature should be implemented in C++ and mainlined into Kakoune, since kakscript will be way slower than C++ for this application. But, if we can get the shell expansions out of crosshairs-highlight-column, this script may be fast enough.

First commit removed the shell expansion from crosshair-update.  
In theory, this should be faster, but I'm not sure how to objectively test UI responsiveness for Kakoune.  
If you have ideas for getting timed performance comparisons, let me know.  
I'm not sure how the shell expansions could be removed from crosshairs-highlight-column, but I think that should be looked into.

Second commit is just a bit of refactoring the public commands that set the hooks.  
I think it's a bit cleaner this way, but if you don't like it, this refactoring commit can be discarded.

Disclaimer:  
I am rather new to writing kakscript. So there may be some better tricks I don't know about.